### PR TITLE
Fixed bug: not being able to find last txt file

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,10 +38,11 @@ def images_annotations_info(opt):
         if image_id % 1000 == 0:
             print("Processing " + str(image_id) + " ...")
 
-        img_file = cv2.imread(line[:-1])
+        line = line.replace('\n', '')
+        img_file = cv2.imread(line)
 
         # read a label file
-        label_path = line[:-4]+"txt"
+        label_path = line[:-3]+"txt"
         label_file = open(label_path,"r")
         label_read_line = label_file.readlines()
         label_file.close()
@@ -49,7 +50,7 @@ def images_annotations_info(opt):
         h, w, _ = img_file.shape
 
         # Create image annotation
-        image = create_image_annotation(line[:-1], w, h, image_id)
+        image = create_image_annotation(line, w, h, image_id)
         images.append(image)
 
         # yolo format - (class_id, x_center, y_center, width, height)


### PR DESCRIPTION
If the train.txt does not have a \n (new line) at the end of the file, the program will crash and not finish. In other words, without this fix, we assume that there always is a \n after every line. This might not be the case for the last line of the file, dependent on how the `train.txt` file was made.

Instead of slicing the new line out of the current line, we instead remove all new lines by the using `.replace()`. Thus, we only have to worry about switching from `.jpg/.png/other` to `.txt`. Before, we had to worry about there being a `.jpg\n/.png\n/other\n`.

It has been adjusted and tested on my custom dataset, and it now works as I think was intended.