### PR TITLE
Features for main.py --path <directory or images.txt> --box2seg --yolo_subdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,53 @@ Just clone this repository.
 ### It will be easy to understand if you refer to the tutorial folder.  
 
 When you have your own Yolo annotation format, just change a little bit!  
-#### 1. Change `classes` with your own dataset.  
+### 1. Change `classes` with your own dataset.  
 In `main.py`, there is a code that declare the classes. You will change this with your `obj.names`.  
 
 <p align="center"><img src="https://user-images.githubusercontent.com/41863759/100314803-cfd36800-2ffa-11eb-90ed-bf821ba2de4f.png" width="400px"></p>  
 
-#### 2. Check the absolute path in `train.txt`.  
+Next, follow step 2 if you have your annotations in separate text files, one for each image.
+Alternatively, follow step 3 if you wish to work from YOLO annotations which are concatenated
+into a single file.
+
+### 2. Prepare COCO annotation file from multiple YOLO annotation files.
+#### 2a. Image and annotation files are side by side
+Use this approach if your training data file structure looks like this:
+<pre>
+    dataset_root_dir/
+        Photo_00001.jpg
+        Photo_00001.txt
+        Photo_00002.jpg
+        Photo_00003.txt
+</pre>
+
+- `python main.py --path <Absolute path to dataset_root_dir> --output <Name of the json file>`  
+- `python main.py --box2seg --path <Absolute path to dataset_root_dir> --output <Name of the json file>`
+- (For example)`python main.py --path /home/taeyoungkim/Desktop/Yolo-to-COCO-format-converter/tutorial/ --output train`  
+
+The arg `--box2seg` initializes segmentation mask polygons that have box shapes.
+This is useful for when changing your modeling from object detection to image segmentation.
+These masks can then be reshaped using software such as the interface provided by makesense.ai
+
+#### 2b. Annotations are nested in a folder 'YOLO_darknet' (OpenLabeling output)
+Use this approach if your annotations are in nested a level below the image files like this:
+<pre>
+    dataset_root_dir/
+        YOLO_darknet/
+            Photo_00001.txt
+            Photo_00002.txt
+        Photo_00001.jpg
+        Photo_00002.jpg
+</pre>
+
+Command to use:
+- `python main.py --yolo-subdir --path <Absolute path to dataset_root_dir> --output <Name of the json file>`
+- `python main.py --yolo-subdir --box2seg --path <Absolute path to dataset_root_dir> --output <Name of the json file>`
+- (For example)`python main.py --path /home/taeyoungkim/Desktop/Yolo-to-COCO-format-converter/tutorial/ --output train`  
+
+
+### 3. Prepare COCO annotation file from a single YOLO annotation file
+#### 3a. Check the absolute path in `train.txt`.  
 Make sure that it points to the absolute path to the folder where the image and text files are located.  
 You can easily change the path with `Text Editor`(Ubuntu 18.04) or `NotePad` (Window 10).  
 
@@ -42,7 +83,7 @@ You can easily change the path with `Text Editor`(Ubuntu 18.04) or `NotePad` (Wi
    
 <p align="center"><img src="https://user-images.githubusercontent.com/41863759/100314808-d366ef00-2ffa-11eb-96fe-f4a2d5ffadb0.png" width="600px"></p>  
 
-#### 2.1  How To Use `path_replacer.py`
+#### 3.1  How To Use `path_replacer.py`
 
   **If you want to quickly create a train.txt file in Ubuntu, you can use path_replacer.py.**
   
@@ -54,7 +95,7 @@ You can easily change the path with `Text Editor`(Ubuntu 18.04) or `NotePad` (Wi
   - `python path_replacer.py --path_image_folder [File path where the images are located] --path_txt [File path of the 'txt' file you want to create]`  
   - (For example)`python path_replacer.py --path_image_folder /home/taeyoungkim/Desktop/Yolo-to-COCO-format-converter/tutorial/train --path_txt /home/taeyoungkim/Desktop/Yolo-to-COCO-format-converter/tutorial/train.txt`
 
-#### 3. Just run the code.  
+#### 3.2 Now run the code.  
 You need to provide 2 argments(essential) & 1 argments(optional).  
 - path : Absolute path of train.txt  
 - output : Name of the json file  

--- a/create_annotations.py
+++ b/create_annotations.py
@@ -1,40 +1,40 @@
-def create_image_annotation(file_name, width, height, image_id):
-    file_name = file_name.split('/')[-1] # ~~~.jpg가 file_name이 되도록 문자열 split
-    images = {
-        'file_name': file_name,
-        'height': height,
-        'width': width,
-        'id': image_id
+from pathlib import Path
+
+
+def create_image_annotation(file_path: Path, width: int, height: int, image_id: int):
+    file_path = file_path.name
+    image_annotation = {
+        "file_name": file_path,
+        "height": height,
+        "width": width,
+        "id": image_id,
     }
-    return images
+    return image_annotation
 
-def create_annotation_yolo_format(min_x, min_y, width, height, image_id, category_id, annotation_id):
-    bbox = (min_x, min_y, width, height)
+
+def create_annotation_from_yolo_format(
+    min_x, min_y, width, height, image_id, category_id, annotation_id, segmentation=True
+):
+    bbox = (float(min_x), float(min_y), float(width), float(height))
     area = width * height
-
+    max_x = min_x + width
+    max_y = min_y + height
+    if segmentation:
+        seg = [[min_x, min_y, max_x, min_y, max_x, max_y, min_x, max_y]]
+    else:
+        seg = []
     annotation = {
-        'id': annotation_id,
-        'image_id': image_id,
-        'bbox': bbox,
-        'area': area,
-        'iscrowd': 0,
-        'category_id': category_id,
-        'segmentation': []
+        "id": annotation_id,
+        "image_id": image_id,
+        "bbox": bbox,
+        "area": area,
+        "iscrowd": 0,
+        "category_id": category_id,
+        "segmentation": seg,
     }
 
     return annotation
 
-# Create the annotations of the ECP dataset (Coco format)
-coco_format = {
-    "images": [
-        {
-        }
-    ],
-    "categories": [
 
-    ],
-    "annotations": [
-        {
-        }
-    ]
-}
+# Create the annotations of the ECP dataset (Coco format)
+coco_format = {"images": [{}], "categories": [], "annotations": [{}]}

--- a/main.py
+++ b/main.py
@@ -1,4 +1,10 @@
-from create_annotations import *
+from pathlib import Path
+
+from create_annotations import (
+    create_image_annotation,
+    create_annotation_from_yolo_format,
+    coco_format,
+)
 import cv2
 import argparse
 import json
@@ -9,98 +15,112 @@ import numpy as np
 # Don't change the list name 'Classes'          #
 #################################################
 
-# Class에 맞게 바꿔줘야함
+YOLO_DARKNET_SUB_DIR = "YOLO_darknet"
+
 classes = [
-"chair",
-"handle",
-"table",
-"button",
-"person",
+    "chair",
+    "handle",
+    "table",
+    "button",
+    "person",
 ]
 
-# Get 'images' and 'annotations' info
-def images_annotations_info(opt):
 
-    path = opt.path
-    # path : train.txt or test.txt
+def get_images_info_and_annotations(opt):
+    path = Path(opt.path)
     annotations = []
-    images = []
-
-    file = open(path, "r")
-    read_lines = file.readlines()
-    file.close()
+    images_annotations = []
+    if path.is_dir():
+        file_paths = sorted(path.rglob("*.jpg"))
+    else:
+        with open(path, "r") as fp:
+            read_lines = fp.readlines()
+        file_paths = [Path(line.replace("\n", "")) for line in read_lines]
 
     image_id = 0
-    annotation_id = 1   # In COCO dataset format, you must start annotation id with '1'
+    annotation_id = 1  # In COCO dataset format, you must start annotation id with '1'
 
-    for line in read_lines:
+    for file_path in file_paths:
         # Check how many items have progressed
         if image_id % 1000 == 0:
             print("Processing " + str(image_id) + " ...")
 
-        line = line.replace('\n', '')
-        img_file = cv2.imread(line)
-
-        # read a label file
-        label_path = line[:-3]+"txt"
-        label_file = open(label_path,"r")
-        label_read_line = label_file.readlines()
-        label_file.close()
-
+        img_file = cv2.imread(str(file_path))
         h, w, _ = img_file.shape
+        image_annotation = create_image_annotation(
+            file_path=file_path, width=w, height=h, image_id=image_id
+        )
+        images_annotations.append(image_annotation)
 
-        # Create image annotation
-        image = create_image_annotation(line, w, h, image_id)
-        images.append(image)
+        label_file_name = f"{file_path.stem}.txt"
+        if opt.yolo_subdir:
+            annotations_path = file_path.parent / YOLO_DARKNET_SUB_DIR / label_file_name
+        else:
+            annotations_path = file_path.parent / label_file_name
+
+        if not annotations_path.exists():
+            continue  # The image may not have any applicable annotation txt file.
+
+        with open(str(annotations_path), "r") as label_file:
+            label_read_line = label_file.readlines()
 
         # yolo format - (class_id, x_center, y_center, width, height)
         # coco format - (annotation_id, x_upper_left, y_upper_left, width, height)
         for line1 in label_read_line:
             label_line = line1
-            category_id = int(label_line.split()[0]) + 1    # you start with annotation id with '1'
+            category_id = (
+                int(label_line.split()[0]) + 1
+            )  # you start with annotation id with '1'
             x_center = float(label_line.split()[1])
             y_center = float(label_line.split()[2])
             width = float(label_line.split()[3])
             height = float(label_line.split()[4])
 
-            int_x_center = int(img_file.shape[1]*x_center)
-            int_y_center = int(img_file.shape[0]*y_center)
-            int_width = int(img_file.shape[1]*width)
-            int_height = int(img_file.shape[0]*height)
+            int_x_center = int(img_file.shape[1] * x_center)
+            int_y_center = int(img_file.shape[0] * y_center)
+            int_width = int(img_file.shape[1] * width)
+            int_height = int(img_file.shape[0] * height)
 
-            min_x = int_x_center-int_width/2
-            min_y = int_y_center-int_height/2
+            min_x = int_x_center - int_width / 2
+            min_y = int_y_center - int_height / 2
             width = int_width
             height = int_height
 
-            annotation = create_annotation_yolo_format(min_x, min_y, width, height, image_id, category_id, annotation_id)
+            annotation = create_annotation_from_yolo_format(
+                min_x,
+                min_y,
+                width,
+                height,
+                image_id,
+                category_id,
+                annotation_id,
+                segmentation=opt.box2seg,
+            )
             annotations.append(annotation)
             annotation_id += 1
 
         image_id += 1  # if you finished annotation work, updates the image id.
 
-    return images, annotations
+    return images_annotations, annotations
 
 
-# Visualize bounding box
 def debug(opt):
-
     path = opt.path
     color_list = np.random.randint(low=0, high=256, size=(len(classes), 3)).tolist()
-    
+
     # read the file
     file = open(path, "r")
     read_lines = file.readlines()
     file.close()
 
     for line in read_lines:
-        print("Image Path : ",line)
+        print("Image Path : ", line)
         # read image file
         img_file = cv2.imread(line[:-1])
 
         # read .txt file
-        label_path = line[:-4]+"txt"
-        label_file = open(label_path,"r")
+        label_path = line[:-4] + "txt"
+        label_file = open(label_path, "r")
         label_read_line = label_file.readlines()
         label_file.close()
 
@@ -113,23 +133,29 @@ def debug(opt):
             width = float(label_line.split()[3])
             height = float(label_line.split()[4])
 
-            int_x_center = int(img_file.shape[1]*x_center)
-            int_y_center = int(img_file.shape[0]*y_center)
-            int_width = int(img_file.shape[1]*width)
-            int_height = int(img_file.shape[0]*height)
+            int_x_center = int(img_file.shape[1] * x_center)
+            int_y_center = int(img_file.shape[0] * y_center)
+            int_width = int(img_file.shape[1] * width)
+            int_height = int(img_file.shape[0] * height)
 
-            min_x = int_x_center-int_width/2
-            min_y = int_y_center-int_height/2
-            width = int(img_file.shape[1]*width)
-            height = int(img_file.shape[0]*height)
+            min_x = int_x_center - int_width / 2
+            min_y = int_y_center - int_height / 2
+            width = int(img_file.shape[1] * width)
+            height = int(img_file.shape[0] * height)
 
             print("class name :", classes[int(category_id)])
-            print("x_upper_left : ",min_x,'\t',"y_upper_left : ",min_y)
-            print("width : ",width,'\t','\t',"height : ",height)
+            print("x_upper_left : ", min_x, "\t", "y_upper_left : ", min_y)
+            print("width : ", width, "\t", "\t", "height : ", height)
             print()
 
             # Draw bounding box
-            cv2.rectangle(img_file, (int(int_x_center-int_width/2), int(int_y_center-int_height/2)), (int(int_x_center+int_width/2), int(int_y_center+int_height/2)), color_list[int(category_id)], 3)
+            cv2.rectangle(
+                img_file,
+                (int(int_x_center - int_width / 2), int(int_y_center - int_height / 2)),
+                (int(int_x_center + int_width / 2), int(int_y_center + int_height / 2)),
+                color_list[int(category_id)],
+                3,
+            )
 
         cv2.imshow(line, img_file)
         delay = cv2.waitKeyEx()
@@ -140,19 +166,44 @@ def debug(opt):
 
         cv2.destroyAllWindows()
 
-def get_args():
-    parser = argparse.ArgumentParser('Yolo format annotations to COCO dataset format')
-    parser.add_argument('-p', '--path', type=str, help='Absolute path for \'train.txt\' or \'test.txt\'')
-    parser.add_argument('--debug', action='store_true' ,help='Visualize bounding box and print annotation information')
-    parser.add_argument('--output', type=str, help='Name the output json file')
 
+def get_args():
+    parser = argparse.ArgumentParser("Yolo format annotations to COCO dataset format")
+    parser.add_argument(
+        "-p",
+        "--path",
+        type=str,
+        help="Absolute path for 'train.txt' or 'test.txt', or the root dir for images.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Visualize bounding box and print annotation information",
+    )
+    parser.add_argument(
+        "--output",
+        default="train_coco.json",
+        type=str,
+        help="Name the output json file",
+    )
+    parser.add_argument(
+        "--yolo-subdir",
+        action="store_true",
+        help="Annotations are stored in a subdir not side by side with images.",
+    )
+    parser.add_argument(
+        "--box2seg",
+        action="store_true",
+        help="Coco segmentation will be populated with a polygon "
+        "that matches replicates the bounding box data.",
+    )
     args = parser.parse_args()
     return args
 
-if __name__ == '__main__':
-    opt = get_args()
+
+def main(opt):
     output_name = opt.output
-    output_path = 'output/' + output_name + '.json'
+    output_path = "output/" + output_name
 
     print("Start!")
 
@@ -160,18 +211,25 @@ if __name__ == '__main__':
         debug(opt)
         print("Debug Finished!")
     else:
-        # start converting format
-        coco_format['images'], coco_format['annotations'] = images_annotations_info(opt)
+        (
+            coco_format["images"],
+            coco_format["annotations"],
+        ) = get_images_info_and_annotations(opt)
 
         for index, label in enumerate(classes):
-            ann = {
-                "supercategory": "Disinfect_5obj",
-                "id": index + 1,  # Index starts with '1' .
-                "name": label
+            categories = {
+                "supercategory": "Defect",
+                "id": index + 1,  # ID starts with '1' .
+                "name": label,
             }
-            coco_format['categories'].append(ann)
+            coco_format["categories"].append(categories)
 
-        with open(output_path, 'w') as outfile:
+        with open(output_path, "w") as outfile:
             json.dump(coco_format, outfile)
 
         print("Finished!")
+
+
+if __name__ == "__main__":
+    options = get_args()
+    main(options)

--- a/path_replacer.py
+++ b/path_replacer.py
@@ -1,20 +1,44 @@
+"""
+Only use this module if you want to retain a text file artifact which
+lists all image names.
+
+If you do not need to retain this artifact, you can just call main.py
+passing in the directory which contains all of the images via the --path
+parameter, instead of passing it a text file which lists all of the image
+file paths.
+
+"""
 import os
 import glob
 import argparse
 
-parser = argparse.ArgumentParser(description="This Python file makes preliminary preparations for the conversion of the outputs obtained in the yolo format to json format.")
-parser.add_argument('-i','--path_image_folder',help="Enter the file path where the images are located.",type=str)
-parser.add_argument('-p','--path_txt',help="Enter the file path of the 'txt' file you want to create.",type=str)
+parser = argparse.ArgumentParser(
+    description="This Python file makes preliminary preparations for the conversion of the outputs obtained in the yolo format to json format."
+)
+parser.add_argument(
+    "-i",
+    "--path_image_folder",
+    help="Enter the file path where the images are located.",
+    type=str,
+)
+parser.add_argument(
+    "-p",
+    "--path_txt",
+    help="Enter the file path of the 'txt' file you want to create.",
+    type=str,
+)
 args = parser.parse_args()
+
+
 def replacer(image_folder, path_txt):
     path = os.path.abspath(image_folder)
     f = open(path_txt, "w")
 
     for i in glob.glob(path + "/*.jpg"):
-        f.write(i+ "\n")
+        f.write(i + "\n")
     print('----File ".txt" created successfully----')
     f.close()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     replacer(args.path_image_folder, args.path_txt)
-    


### PR DESCRIPTION
Hi, 

I understand there is way too much in here for one branch, plus I used the 'black' formatting lib so not many lines haven't been changed.

Please let me know if you would like individual pull request provided for any of the following features in this PR:
* main.py --path | Changed code so that you can pass a directory instead OR a text file.  That way you only have to run one command instead of running path_replacer.py in advance of main.py
* main.py --box2seg | I made this so I can port my yolo bounding boxes over to segmentation for use in Mask-RCNN modelling. This will save a lot of time preparing polygons, particularly when a box shaped polygon is acceptable.
* main.py --yolo-subdir | I made this because I've been using OpenLabeling which puts image annotations in a sub-directory call 'YOLO_darknet'.

I'd be happy to create unit tests to support any of these features.