### PR TITLE
Formatted json output with indent=4.

### DIFF
--- a/main.py
+++ b/main.py
@@ -225,7 +225,7 @@ def main(opt):
             coco_format["categories"].append(categories)
 
         with open(output_path, "w") as outfile:
-            json.dump(coco_format, outfile)
+            json.dump(coco_format, outfile, indent=4)
 
         print("Finished!")
 


### PR DESCRIPTION
@Taeyoung96 This PR will eliminate the need to JQ the COCO output file.  The file will be slightly larger (due to extra tabs and carriage returns) than the minimized version that the code currently produces.  Is minimisation critical to you?