### PR TITLE
Fixed casting problem with negative bonding-box coco annotation values

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,15 +76,15 @@ def get_images_info_and_annotations(opt):
             width = float(label_line.split()[3])
             height = float(label_line.split()[4])
 
-            int_x_center = int(img_file.shape[1] * x_center)
-            int_y_center = int(img_file.shape[0] * y_center)
-            int_width = int(img_file.shape[1] * width)
-            int_height = int(img_file.shape[0] * height)
+            float_x_center = img_file.shape[1] * x_center
+            float_y_center = img_file.shape[0] * y_center
+            float_width = img_file.shape[1] * width
+            float_height = img_file.shape[0] * height
 
-            min_x = int_x_center - int_width / 2
-            min_y = int_y_center - int_height / 2
-            width = int_width
-            height = int_height
+            min_x = int(float_x_center - float_width / 2)
+            min_y = int(float_y_center - float_height / 2)
+            width = int(float_width)
+            height = int(float_height)
 
             annotation = create_annotation_from_yolo_format(
                 min_x,


### PR DESCRIPTION
Hi, i'm Tobia. I am a master computer engineering student based in Italy.
Thanks for this Yolo/COCO conversion project, it helped me througth my bachelor thesis, and now on my researches.

I wanted to make this pull request after being struggled with a warning coming from a bug, i would call it...

I incurred in the problem during the training of the NN [EfficientDet](https://github.com/xuannianz/EfficientDet).
During the training a Keras UserWarning compared saying that the values of some **bounding-boxes** were **invalid**. I run the train with a COCO format dataset obtained by the conversion from a Yolo format dataset, thanks to your python code.

I bring you an example of a bounding box causing these kind of errors:
Yolo (original format) --> `[0 0.6775701 0.113559 0.19845 0.2271]`
COCO (converted format) --> `[369.5 -0.5 496.5 108.5]` 

_In facts, I tried to manually apply formulas of your "main.py" code, and the result is the same._

Here the problem is clear: I have as a result a **negative value** on the `y_min` value. This will cause an invalid bbox because it would mean which the bbox stands partially outside from the image, which is not possible and it doesn't really match with the Yolo bb format.

I think that this problem mainly comes from the way you are computing `x_min, y_min`.

Your code:
```
x_center = float(label_line.split()[1])
y_center = float(label_line.split()[2])
width = float(label_line.split()[3])
height = float(label_line.split()[4])

int_x_center = int(img_file.shape[1] * x_center)
int_y_center = int(img_file.shape[0] * y_center)
int_width = int(img_file.shape[1] * width)
int_height = int(img_file.shape[0] * height)

min_x = int_x_center - int_width / 2
min_y = int_y_center - int_height / 2
width = int_width
height = int_height
```
The values coming from coco bboxes are all explicitly casted to floats and that is ok. The problem comes with the `int` cast in the following 4 formulas.

I'll make an example with the above Yolo values. Mi image shape is 480x640.

```
y_center = 0.113559
height = 0.2271
int_y_center = int(480 * 0.113559) = 54
int_height = int(480 * 0.2271) = 109
min_y = 54 - 109 / 2 = -0.5
```
Here's why the result is -0.5, the previous values are explicitly casted to int, and in python the operator `/` makes an implicit cast to float, so 109 / 2 will result > than 54.

In my code i basically removed the int() eplicit cast, and I casted to int after all the conversions.
This solved all Keras userWarnings that I've got before! :)